### PR TITLE
Update columns in clock table when changing primary keys.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,8 @@
 name: publish
 
+permissions:
+  contents: write
+
 on:
   push:
     tags:

--- a/.github/workflows/py-tests.yaml
+++ b/.github/workflows/py-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           cd core
           make loadable
 
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           auto-activate-base: true

--- a/core/Makefile
+++ b/core/Makefile
@@ -72,6 +72,8 @@ dbg_prefix=./dbg
 bundle=bundle_static
 valgrind: bundle = integration_check
 test: bundle = integration_check
+ubsan: bundle = integration_check
+asan: bundle = integration_check
 
 TARGET_LOADABLE=$(prefix)/crsqlite.$(LOADABLE_EXTENSION)
 TARGET_DBG_LOADABLE=$(dbg_prefix)/crsqlite.$(LOADABLE_EXTENSION)
@@ -124,7 +126,10 @@ valgrind: $(TARGET_TEST)
 	valgrind $(prefix)/test
 analyzer:
 	scan-build $(MAKE) clean loadable
-ubsan: CC=clang
+asan: export RUSTFLAGS=-Zsanitizer=address
+asan: rs_build_flags=--target x86_64-unknown-linux-gnu -Zbuild-std
+asan: rs_lib_dbg_static=./rs/$(bundle)/target/x86_64-unknown-linux-gnu/debug/libcrsql_$(bundle).a
+asan: CC=clang
 ubsan: LDLIBS += -lubsan
 ubsan: clean $(TARGET_TEST)
 	$(prefix)/test
@@ -255,7 +260,7 @@ $(TARGET_TEST): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(e
 	$(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(ext_files) $(rs_lib_dbg_static_cpy) \
 	$(LDLIBS) -o $@
 
-$(TARGET_TEST_ASAN): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(ext_files)
+$(TARGET_TEST_ASAN): $(prefix) $(TARGET_SQLITE3_EXTRA_C) src/tests.c src/*.test.c $(ext_files) $(rs_lib_dbg_static_cpy)
 	$(CC) -fsanitize=address -g -fno-omit-frame-pointer -Wall \
 	-DSQLITE_THREADSAFE=0 \
 	-DSQLITE_OMIT_LOAD_EXTENSION=1 \

--- a/core/rs/core/src/lib.rs
+++ b/core/rs/core/src/lib.rs
@@ -548,7 +548,7 @@ unsafe extern "C" fn x_crsql_as_crr(
 ) {
     if argc == 0 {
         ctx.result_error(
-            "Wrong number of args provided to crsql_as_crr. Provide the schema 
+            "Wrong number of args provided to crsql_as_crr. Provide the schema
           name and table name or just the table name.",
         );
         return;
@@ -609,7 +609,7 @@ unsafe extern "C" fn x_crsql_begin_alter(
 ) {
     if argc == 0 {
         ctx.result_error(
-            "Wrong number of args provided to crsql_begin_alter. Provide the 
+            "Wrong number of args provided to crsql_begin_alter. Provide the
           schema name and table name or just the table name.",
         );
         return;
@@ -620,7 +620,7 @@ unsafe extern "C" fn x_crsql_begin_alter(
     let (_schema_name, table_name) = if argc == 2 {
         (args[0].text(), args[1].text())
     } else {
-        ("main", args[0].text())
+        ("main\0", args[0].text())
     };
 
     let db = ctx.db_handle();
@@ -645,7 +645,7 @@ unsafe extern "C" fn x_crsql_commit_alter(
 ) {
     if argc == 0 {
         ctx.result_error(
-            "Wrong number of args provided to crsql_commit_alter. Provide the 
+            "Wrong number of args provided to crsql_commit_alter. Provide the
           schema name and table name or just the table name.",
         );
         return;
@@ -655,7 +655,7 @@ unsafe extern "C" fn x_crsql_commit_alter(
     let (schema_name, table_name) = if argc >= 2 {
         (args[0].text(), args[1].text())
     } else {
-        ("main", args[0].text())
+        ("main\0", args[0].text())
     };
 
     let non_destructive = if argc >= 3 { args[2].int() == 1 } else { false };

--- a/core/rs/core/src/local_writes/after_update.rs
+++ b/core/rs/core/src/local_writes/after_update.rs
@@ -74,7 +74,7 @@ fn after_update(
     let next_db_version = crate::db_version::next_db_version(db, ext_data, None)?;
     let new_key = tbl_info
         .get_or_create_key_via_raw_values(db, pks_new)
-        .or_else(|_| Err("failed geteting or creating lookaside key"))?;
+        .or_else(|_| Err("failed getting or creating lookaside key"))?;
 
     // Changing a primary key column to a new value is the same thing as deleting the row
     // previously identified by the primary key.
@@ -85,8 +85,8 @@ fn after_update(
         let next_seq = super::bump_seq(ext_data);
         // Record the delete of the row identified by the old primary keys
         after_update__mark_old_pk_row_deleted(db, tbl_info, old_key, next_db_version, next_seq)?;
-        // TODO: each non sentinel needs a unique seq on the move?
         let next_seq = super::bump_seq(ext_data);
+        // todo: we don't need to this, if there's no existing row (cl is assumed to be 1).
         super::mark_new_pk_row_created(db, tbl_info, new_key, next_db_version, next_seq)?;
         for col in tbl_info.non_pks.iter() {
             let next_seq = super::bump_seq(ext_data);

--- a/py/correctness/tests/test_cl_triggers.py
+++ b/py/correctness/tests/test_cl_triggers.py
@@ -389,8 +389,8 @@ def test_change_primary_key_from_another_db():
 
     c2.execute("UPDATE OR REPLACE foo SET a = 3 WHERE a = 1")
     c2.commit()
-    assert (c2.execute("SELECT crsql_db_version()").fetchone()[0] == 1)
-    sync_left_to_right(c2, c1, 0)
+    assert (c2.execute("SELECT crsql_db_version()").fetchone()[0] == 2)
+    sync_left_to_right(c2, c1, 1)
 
     changes = c2.execute(
         "SELECT pk, cid, cl FROM crsql_changes").fetchall()
@@ -400,8 +400,8 @@ def test_change_primary_key_from_another_db():
     # and it is alive at version 3 given it iassert (changes2 == changes)s a re-insertion of the currently existing row
     # pk 1 is dead (cl of 2) given we mutated / updated away from it. E.g.,
     # set a = 2 where a = 1
-    assert (changes == [(b'\x01\t\x01', '-1', 2), (b'\x01\t\x03', '-1', 1),
-                        (b'\x01\t\x02', 'b', 1), (b'\x01\t\x03', 'b', 1)])
+    assert (changes == [(b'\x01\t\x02', 'b', 1), (b'\x01\t\x01', '-1', 2), (b'\x01\t\x03', '-1', 1),
+                        (b'\x01\t\x03', 'b', 1)])
     # assert (changes2 == changes)
 
     # Verify both nodes have same data after final sync

--- a/py/correctness/tests/test_update_rows.py
+++ b/py/correctness/tests/test_update_rows.py
@@ -1,2 +1,67 @@
 from crsql_correctness import connect
 
+def sync_left_to_right(l, r, since):
+    changes = l.execute(
+        "SELECT * FROM crsql_changes WHERE db_version > ?", (since,))
+    for change in changes:
+        r.execute(
+            "INSERT INTO crsql_changes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", change)
+    r.commit()
+
+def test_update_pk():
+    def create_db():
+        db = connect(":memory:")
+        db.execute("CREATE TABLE foo (id INTEGER PRIMARY KEY NOT NULL, a, b)")
+        db.execute("SELECT crsql_as_crr('foo');")
+        db.commit()
+        return db
+
+    def get_site_id(db):
+        return db.execute("SELECT crsql_site_id()").fetchone()[0]
+
+    db1 = create_db()
+    db2 = create_db()
+
+    db1_site_id = get_site_id(db1)
+    db2_site_id = get_site_id(db2)
+
+    db1.execute("INSERT INTO foo (id, a, b) VALUES (1, 2, 3)")
+    db1.commit()
+
+    db1.execute("INSERT INTO foo (id, a, b) VALUES (2, 5, 6)")
+    db1.commit()
+
+    sync_left_to_right(db1, db2, 0)
+
+    db1_changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
+
+    assert (db1_changes == [('foo', b'\x01\t\x01', 'a', 2, 1, 1, db1_site_id, 1, 0),
+                    ('foo', b'\x01\t\x01', 'b', 3, 1, 1, db1_site_id, 1, 1),
+                    ('foo', b'\x01\t\x02', 'a', 5, 1, 2, db1_site_id, 1, 0),
+                    ('foo', b'\x01\t\x02', 'b', 6, 1, 2, db1_site_id, 1, 1)])
+
+    db2_changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
+    assert (db2_changes == db1_changes)
+
+    # update primary key
+    db1.execute("UPDATE foo SET id = 10 WHERE id = 1")
+    db1.commit()
+
+    db1_foo = db1.execute("SELECT * FROM foo").fetchall()
+    assert (db1_foo == [(2, 5, 6), (10, 2, 3)])
+
+    db1_changes = db1.execute("SELECT * FROM crsql_changes").fetchall()
+    assert (db1_changes == [('foo', b'\x01\t\x02', 'a', 5, 1, 2, db1_site_id, 1, 0),
+                ('foo', b'\x01\t\x02', 'b', 6, 1, 2, db1_site_id, 1, 1),
+                ('foo', b'\x01\t\x01', '-1', None, 2, 3, db1_site_id, 2, 0),
+                ('foo', b'\x01\t\n', '-1', None, 1, 3, db1_site_id, 1, 1),
+                ('foo', b'\x01\t\n', 'a', 2, 2, 3, db1_site_id, 1, 2),
+                ('foo', b'\x01\t\n', 'b', 3, 2, 3, db1_site_id, 1, 3)])
+
+    sync_left_to_right(db1, db2, 2)
+
+    db2_changes = db2.execute("SELECT * FROM crsql_changes").fetchall()
+    assert (db2_changes == db1_changes)
+
+    db2_foo = db2.execute("SELECT * FROM foo").fetchall()
+    assert (db2_foo == db1_foo)


### PR DESCRIPTION
This pull request updates the db_version, col_version, site_id and seq columns in the clock tables when changing the primary key on a table. Without doing this a following node will not get the new changes (since the db_version on the changed rows stayed the same) and would have incorrect data.